### PR TITLE
Add dedicated optimization pass for fusion

### DIFF
--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -223,10 +223,10 @@ def new_collection(expr):
         return Scalar(expr)
 
 
-def optimize(collection):
+def optimize(collection, fuse=True):
     from dask_match.core import optimize_expr
 
-    return new_collection(optimize_expr(collection.expr))
+    return new_collection(optimize_expr(collection.expr, fuse=fuse))
 
 
 def from_pandas(*args, **kwargs):

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -117,6 +117,10 @@ class FrameBase(DaskMethodsMixin):
             out = out.compute()
         return out
 
+    def copy(self):
+        """ Return a copy of this object """
+        return new_collection(self.expr)
+
 
 # Add operator attributes
 for op in [

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -232,9 +232,9 @@ def new_collection(expr):
 
 
 def optimize(collection, fuse=True):
-    from dask_match.core import optimize_expr
+    from dask_match.core import optimize
 
-    return new_collection(optimize_expr(collection.expr, fuse=fuse))
+    return new_collection(optimize(collection.expr, fuse=fuse))
 
 
 def from_pandas(*args, **kwargs):

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -188,6 +188,10 @@ class DataFrame(FrameBase):
 class Series(FrameBase):
     """Series-like Expr Collection"""
 
+    @property
+    def name(self):
+        return self.expr._meta.name
+
     def __repr__(self):
         return f"<dask_match.core.Series: expr={self.expr}>"
 

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -118,7 +118,7 @@ class FrameBase(DaskMethodsMixin):
         return out
 
     def copy(self):
-        """ Return a copy of this object """
+        """Return a copy of this object"""
         return new_collection(self.expr)
 
 

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -374,6 +374,7 @@ class Blockwise(Expr):
     def _name(self):
         return funcname(self.operation) + "-" + tokenize(*self.operands)
 
+    @functools.lru_cache
     def _blockwise_subgraph(self):
         args = tuple(
             operand._name if isinstance(operand, Expr) else operand
@@ -384,6 +385,7 @@ class Blockwise(Expr):
         else:
             return {self._name: (self.operation,) + args}
 
+    @functools.lru_cache
     def _layer(self):
         # Use BlockwiseArg to broadcast dependencies (if necessary)
         dependencies = [
@@ -878,6 +880,7 @@ class FusedExpr(Blockwise):
     def dependencies(self):
         return self.operands[1:]
 
+    @functools.lru_cache
     def _blockwise_subgraph(self):
         block = {self._name: self.exprs[0]._name}
         for _expr in self.exprs:

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -769,7 +769,7 @@ def _blockwise_fusion(expr):
 
 class FusedExpr(Blockwise):
     """Fused ``Blockwise`` expression
-    
+
     A ``FusedExpr`` corresponds to the fusion of multiple
     ``Blockwise`` expressions into a single ``Expr`` object.
     Before graph-materialization time, the behavior of this
@@ -791,6 +791,7 @@ class FusedExpr(Blockwise):
         operands, because those arguments should already be
         captured in the fused subgraphs.
     """
+
     _parameters = ["exprs"]
 
     @property

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -344,7 +344,7 @@ class Blockwise(Expr):
             (self._name, i): (
                 func,
                 *[
-                    dep[i] if isinstance(dep, MappedArg) else (dep._name, i)
+                    dep[i] if isinstance(dep, IndexableArg) else (dep._name, i)
                     for dep in dependencies
                 ],
             )
@@ -775,9 +775,7 @@ def _blockwise_fusion(expr):
 
 
 class FusedExpr(Blockwise):
-    @property
-    def exprs(self):
-        return self.operands[0]
+    _parameters = ["exprs"]
 
     @property
     def _meta(self):
@@ -805,7 +803,7 @@ class FusedExpr(Blockwise):
         return block
 
 
-class MappedArg:
+class IndexableArg:
     """Indexable Expr dependency
 
     NOTE: This class is used by IO expressions
@@ -820,7 +818,7 @@ class MappedArg:
 
     @property
     def _name(self):
-        return f"mapped-arg-{self.token}"
+        return f"indexable-arg-{self.token}"
 
     def __getitem__(self, index):
         if callable(self.lookup):

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -595,15 +595,6 @@ class Binop(Elemwise):
     _parameters = ["left", "right"]
     arity = Arity.binary
 
-    def _blockwise_layer(self):
-        return {
-            self._name: (
-                self.operation,
-                self.left._name if isinstance(self.left, Expr) else self.left,
-                self.right._name if isinstance(self.right, Expr) else self.right,
-            )
-        }
-
     def __str__(self):
         return f"{self.left} {self._operator_repr} {self.right}"
 

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -369,7 +369,6 @@ class Blockwise(Expr):
     def _name(self):
         return funcname(self.operation) + "-" + tokenize(*self.operands)
 
-    @functools.lru_cache
     def _blockwise_subgraph(self):
         args = tuple(
             operand._name if isinstance(operand, Expr) else operand
@@ -380,7 +379,6 @@ class Blockwise(Expr):
         else:
             return {self._name: (self.operation,) + args}
 
-    @functools.lru_cache
     def _layer(self):
         # Use BlockwiseArg to broadcast dependencies (if necessary)
         dependencies = [

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -412,9 +412,20 @@ class Blockwise(Expr):
 class BlockwiseArg(Expr):
     """Indexable Blockwise argument
 
-    NOTE: This class is used by IO expressions
-    to map path-like arguments over output partitions
-    in a fusion-compatible way.
+    This class is used by IO expressions to map path-like
+    arguments over output partitions in a fusion-compatible way.
+
+    Parameters
+    ----------
+    lookup: Sequence
+        Indexable sequence that should return a task argument
+        for a given parition index (e.g. ``[0, npartitions]``).
+        Note that ``Blockwise._layer`` will eagerly populate
+        leteral partition-dependent task arguments at graph
+        creation time using ``BlockwiseArg`` dependencies.
+    name: str, optional
+        Custom expression name. This operand should be specified
+        if ``lookup`` does not produce a deterministic hash.
     """
 
     _parameters = ["lookup", "name"]
@@ -429,7 +440,6 @@ class BlockwiseArg(Expr):
         return self.operand("name") or f"arg-{tokenize(self.lookup)}"
 
     def _divisions(self):
-        assert isinstance(self.lookup, (list, dict))
         return (None,) * (len(self.lookup) + 1)
 
     def __getitem__(self, index):

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -636,6 +636,9 @@ def optimize_expr(expr, fuse=True):
 from dask_match.reductions import Count, Max, Min, Mode, Size, Sum
 
 
+## Utilites for Expr fusion
+
+
 def replace_nodes(expr, nodes_to_replace: dict):
     """Replace specific nodes in an Expr tree
 
@@ -725,8 +728,7 @@ def _blockwise_fusion(expr):
 
                 group.append(next)
                 for dep in dependencies[next]:
-                    missing = dependents[dep] - set(stack) - set(group)
-                    if not missing:
+                    if not (dependents[dep] - set(stack) - set(group)):
                         # All of deps dependents are contained
                         # in the local group (or the local stack
                         # of expr nodes that we know we will be

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -87,7 +87,7 @@ class Expr(Operation, metaclass=_ExprMeta):
         """Rules associated to this class that are useful for optimization
 
         See also:
-            optimize_expr
+            optimize
             _ExprMeta
         """
         yield from []
@@ -701,7 +701,7 @@ def normalize_expression(expr):
     return expr._name
 
 
-def optimize_expr(expr, fuse=True):
+def optimize(expr, fuse=True):
     """High level query optimization
 
     Today we just use MatchPy's term rewriting system, leveraging the

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -655,7 +655,6 @@ def replace_nodes(expr, nodes_to_replace: dict):
     new_operands = []
     new_count = 0
     for operand in expr.operands:
-
         if isinstance(operand, Expr) and operand in nodes_to_replace:
             # Replacing this operand
             val = nodes_to_replace[operand]
@@ -680,7 +679,6 @@ def _blockwise_fusion(expr):
     """Traverse the expression graph and apply fusion"""
 
     def _fusion_pass(expr):
-
         # Full pass to find global dependencies
         seen = set()
         stack = [expr]
@@ -787,7 +785,6 @@ class Fusable(Protocol):
 
 
 class FusedExpr(Expr):
-
     @property
     def exprs(self):
         return self.operands[0]
@@ -797,7 +794,7 @@ class FusedExpr(Expr):
         return self.exprs[0]._meta
 
     def __str__(self):
-        descr = "-".join([expr._name.split('-')[0] for expr in self.exprs])
+        descr = "-".join([expr._name.split("-")[0] for expr in self.exprs])
         return f"Fused-{descr}"
 
     @property

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -768,6 +768,29 @@ def _blockwise_fusion(expr):
 
 
 class FusedExpr(Blockwise):
+    """Fused ``Blockwise`` expression
+    
+    A ``FusedExpr`` corresponds to the fusion of multiple
+    ``Blockwise`` expressions into a single ``Expr`` object.
+    Before graph-materialization time, the behavior of this
+    object should be identical to that of the first element
+    of ``FusedExpr.exprs`` (i.e. the top-most expression in
+    the fused group).
+
+    Parameters
+    ----------
+    exprs : List[Expr]
+        Group of original ``Expr`` objects being fused together.
+    *dependencies:
+        List of ``IndexableArg`` arguments and external-``Expr``
+        dependencies. External-``Expr``dependencies correspond to
+        any ``Expr`` operand that is not already included in
+        ``exprs``. Note that these dependencies should be defined
+        in the order of the ``Expr`` objects that require them
+        (in ``exprs``). These dependencies do not include literal
+        operands, because those arguments should already be
+        captured in the fused subgraphs.
+    """
     _parameters = ["exprs"]
 
     @property

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -728,7 +728,6 @@ def optimize_expr(expr, fuse=True):
         _defer_to_matchpy = False
 
     if fuse:
-        # Apply fusion
         expr = _blockwise_fusion(expr)
 
     return expr
@@ -811,7 +810,7 @@ def _blockwise_fusion(expr):
                         for operand in _expr.dependencies()
                         if operand._name not in local_names
                     ]
-                to_replace = {group[0]: FusedExpr(group, *group_deps)}
+                to_replace = {group[0]: Fused(group, *group_deps)}
                 return expr.substitute(to_replace), not roots
 
         # Return original expr if no fusable sub-groups were found
@@ -826,14 +825,14 @@ def _blockwise_fusion(expr):
     return expr
 
 
-class FusedExpr(Blockwise):
+class Fused(Blockwise):
     """Fused ``Blockwise`` expression
 
-    A ``FusedExpr`` corresponds to the fusion of multiple
+    A ``Fused`` corresponds to the fusion of multiple
     ``Blockwise`` expressions into a single ``Expr`` object.
     Before graph-materialization time, the behavior of this
     object should be identical to that of the first element
-    of ``FusedExpr.exprs`` (i.e. the top-most expression in
+    of ``Fused.exprs`` (i.e. the top-most expression in
     the fused group).
 
     Parameters

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -446,9 +446,9 @@ class BlockwiseArg(Expr):
         return self.lookup[index]
 
     def _layer(self):
-        # A `BlockwiseArg` should never produce a graph here.
-        # The parent `Blockwise._layer` layer method should
-        # index this object to eagerly populate its graph
+        # `BlockwiseArg` should never produce a graph.
+        # The parent `Blockwise._layer` method should
+        # index this object to populate its graph
         # with the values of `BlockwiseArg.lookup`
         return {}
 

--- a/dask_match/core.py
+++ b/dask_match/core.py
@@ -287,7 +287,7 @@ class Expr(Operation, metaclass=_ExprMeta):
         if not substitutions:
             # Nothing to replace
             return self
-        
+
         targets, replacements = [], []
         for target, replacement in substitutions:
             assert isinstance(target, Expr)
@@ -841,9 +841,7 @@ class IndexableArg:
     def __init__(self, lookup, name=None, token=None):
         assert callable(lookup) or isinstance(lookup, (list, dict))
         self._lookup = lookup
-        self._name = name or (
-            f"indexable-arg-{token or tokenize(self._lookup)}"
-        )
+        self._name = name or (f"indexable-arg-{token or tokenize(self._lookup)}")
 
     def __getitem__(self, index):
         if callable(self._lookup):

--- a/dask_match/io/csv.py
+++ b/dask_match/io/csv.py
@@ -1,9 +1,12 @@
 import functools
 
-from dask_match.io.io import IO
+from dask.base import tokenize
+
+from dask_match.core import MappedArg
+from dask_match.io.io import BlockwiseIO
 
 
-class ReadCSV(IO):
+class ReadCSV(BlockwiseIO):
     _parameters = ["filename", "usecols", "header"]
     _defaults = {"usecols": None, "header": "infer"}
 
@@ -25,7 +28,20 @@ class ReadCSV(IO):
     def _divisions(self):
         return self._ddf.divisions
 
-    def _layer(self):
+    @property
+    def _tasks(self):
+        return list(self._ddf.dask.to_dict().values())
+
+    @functools.lru_cache
+    def _subgraph_dependencies(self):
+        # Need to pass `token` to ensure deterministic name
+        return [MappedArg([t[1] for t in self._tasks], token=tokenize(self._ddf))]
+
+    def _blockwise_subgraph(self):
+        dsk = self._tasks[0][0].dsk
         return {
-            (self._name, i): k for i, k in enumerate(self._ddf.dask.to_dict().values())
+            self._name: (
+                next(iter(dsk.values()))[0],
+                self._subgraph_dependencies()[0]._name,
+            )
         }

--- a/dask_match/io/csv.py
+++ b/dask_match/io/csv.py
@@ -2,7 +2,7 @@ import functools
 
 from dask.base import tokenize
 
-from dask_match.core import MappedArg
+from dask_match.core import IndexableArg
 from dask_match.io.io import BlockwiseIO
 
 
@@ -35,7 +35,7 @@ class ReadCSV(BlockwiseIO):
     @functools.lru_cache
     def dependencies(self):
         # Need to pass `token` to ensure deterministic name
-        return [MappedArg([t[1] for t in self._tasks], token=tokenize(self._ddf))]
+        return [IndexableArg([t[1] for t in self._tasks], token=tokenize(self._ddf))]
 
     def _blockwise_subgraph(self):
         dsk = self._tasks[0][0].dsk

--- a/dask_match/io/csv.py
+++ b/dask_match/io/csv.py
@@ -38,7 +38,8 @@ class ReadCSV(BlockwiseIO):
     @functools.lru_cache
     def dependencies(self):
         # Need to pass `token` to ensure deterministic name
-        return [BlockwiseArg([t[1] for t in self._tasks], token=tokenize(self._ddf))]
+        name = f"csvdep-{tokenize(self._ddf)}"
+        return [BlockwiseArg([t[1] for t in self._tasks], name)]
 
     def _blockwise_subgraph(self):
         dsk = self._tasks[0][0].dsk

--- a/dask_match/io/csv.py
+++ b/dask_match/io/csv.py
@@ -10,6 +10,9 @@ class ReadCSV(BlockwiseIO):
     _parameters = ["filename", "usecols", "header"]
     _defaults = {"usecols": None, "header": "infer"}
 
+    def __str__(self):
+        return f"{type(self).__name__}({self.filename})"
+
     @functools.cached_property
     def _ddf(self):
         # Temporary hack to simplify logic

--- a/dask_match/io/csv.py
+++ b/dask_match/io/csv.py
@@ -35,13 +35,12 @@ class ReadCSV(BlockwiseIO):
     def _tasks(self):
         return list(self._ddf.dask.to_dict().values())
 
-    @functools.lru_cache
     def dependencies(self):
         # Need to pass `token` to ensure deterministic name
         name = f"csvdep-{tokenize(self._ddf)}"
         return [BlockwiseArg([t[1] for t in self._tasks], name)]
 
-    def _blockwise_subgraph(self):
+    def _blockwise_layer(self):
         dsk = self._tasks[0][0].dsk
         return {
             self._name: (

--- a/dask_match/io/csv.py
+++ b/dask_match/io/csv.py
@@ -33,7 +33,7 @@ class ReadCSV(BlockwiseIO):
         return list(self._ddf.dask.to_dict().values())
 
     @functools.lru_cache
-    def _subgraph_dependencies(self):
+    def dependencies(self):
         # Need to pass `token` to ensure deterministic name
         return [MappedArg([t[1] for t in self._tasks], token=tokenize(self._ddf))]
 
@@ -42,6 +42,6 @@ class ReadCSV(BlockwiseIO):
         return {
             self._name: (
                 next(iter(dsk.values()))[0],
-                self._subgraph_dependencies()[0]._name,
+                self.dependencies()[0]._name,
             )
         }

--- a/dask_match/io/csv.py
+++ b/dask_match/io/csv.py
@@ -2,7 +2,7 @@ import functools
 
 from dask.base import tokenize
 
-from dask_match.core import IndexableArg
+from dask_match.core import BlockwiseArg
 from dask_match.io.io import BlockwiseIO
 
 
@@ -38,7 +38,7 @@ class ReadCSV(BlockwiseIO):
     @functools.lru_cache
     def dependencies(self):
         # Need to pass `token` to ensure deterministic name
-        return [IndexableArg([t[1] for t in self._tasks], token=tokenize(self._ddf))]
+        return [BlockwiseArg([t[1] for t in self._tasks], token=tokenize(self._ddf))]
 
     def _blockwise_subgraph(self):
         dsk = self._tasks[0][0].dsk

--- a/dask_match/io/io.py
+++ b/dask_match/io/io.py
@@ -68,7 +68,7 @@ class FromPandas(BlockwiseIO):
     def dependencies(self):
         return [BlockwiseArg(self._chunks)]
 
-    def _blockwise_subgraph(self):
+    def _blockwise_layer(self):
         return {self._name: self.dependencies()[0]._name}
 
     def __str__(self):

--- a/dask_match/io/io.py
+++ b/dask_match/io/io.py
@@ -1,7 +1,7 @@
 import math
 from functools import cached_property
 
-from dask_match.core import Expr, Blockwise, MappedArg
+from dask_match.core import Expr, Blockwise, IndexableArg
 
 
 class IO(Expr):
@@ -59,7 +59,7 @@ class FromPandas(BlockwiseIO):
         ]
 
     def dependencies(self):
-        return [MappedArg(self._chunks)]
+        return [IndexableArg(self._chunks)]
 
     def _blockwise_subgraph(self):
         return {self._name: self.dependencies()[0]._name}

--- a/dask_match/io/io.py
+++ b/dask_match/io/io.py
@@ -58,11 +58,11 @@ class FromPandas(BlockwiseIO):
             for start, stop in zip(locations[:-1], locations[1:])
         ]
 
-    def _subgraph_dependencies(self):
+    def dependencies(self):
         return [MappedArg(self._chunks)]
 
     def _blockwise_subgraph(self):
-        return {self._name: self._subgraph_dependencies()[0]._name}
+        return {self._name: self.dependencies()[0]._name}
 
     def __str__(self):
         return "df"

--- a/dask_match/io/io.py
+++ b/dask_match/io/io.py
@@ -5,7 +5,8 @@ from dask_match.core import Expr, Blockwise, IndexableArg
 
 
 class IO(Expr):
-    pass
+    def __str__(self):
+        return f"{type(self).__name__}({self._name[-7:]})"
 
 
 class FromGraph(IO):

--- a/dask_match/io/io.py
+++ b/dask_match/io/io.py
@@ -5,7 +5,6 @@ from dask_match.core import Expr, MappedArg, Fusable, _subgraph_callable_layer
 
 
 class IO(Expr):
-
     def _layer(self):
         if isinstance(self, Fusable):
             return _subgraph_callable_layer(

--- a/dask_match/io/io.py
+++ b/dask_match/io/io.py
@@ -1,7 +1,7 @@
 import math
 from functools import cached_property
 
-from dask_match.core import Expr, Blockwise, IndexableArg
+from dask_match.core import Expr, Blockwise, BlockwiseArg
 
 
 class IO(Expr):
@@ -60,7 +60,7 @@ class FromPandas(BlockwiseIO):
         ]
 
     def dependencies(self):
-        return [IndexableArg(self._chunks)]
+        return [BlockwiseArg(self._chunks)]
 
     def _blockwise_subgraph(self):
         return {self._name: self.dependencies()[0]._name}

--- a/dask_match/io/parquet.py
+++ b/dask_match/io/parquet.py
@@ -13,7 +13,7 @@ from dask.utils import natural_sort_key
 from matchpy import CustomConstraint, Pattern, ReplacementRule, Wildcard
 
 from dask_match.core import EQ, GE, GT, LE, LT, NE, Filter, MappedArg
-from dask_match.io import IO
+from dask_match.io import BlockwiseIO
 
 NONE_LABEL = "__null_dask_index__"
 
@@ -27,7 +27,7 @@ def _list_columns(columns):
     return columns
 
 
-class ReadParquet(IO):
+class ReadParquet(BlockwiseIO):
     """Read a parquet dataset"""
 
     _parameters = [
@@ -302,6 +302,6 @@ class ReadParquet(IO):
     def _subgraph_dependencies(self):
         return [MappedArg(self._plan["parts"])]
 
-    def _block_subgraph(self):
+    def _blockwise_subgraph(self):
         dep = self._subgraph_dependencies()[0]._name
         return {self._name: (self._plan["func"], dep)}

--- a/dask_match/io/parquet.py
+++ b/dask_match/io/parquet.py
@@ -12,7 +12,7 @@ from dask.dataframe.io.parquet.utils import _split_user_options
 from dask.utils import natural_sort_key
 from matchpy import CustomConstraint, Pattern, ReplacementRule, Wildcard
 
-from dask_match.core import EQ, GE, GT, LE, LT, NE, Filter, IndexableArg
+from dask_match.core import EQ, GE, GT, LE, LT, NE, Filter, BlockwiseArg
 from dask_match.io import BlockwiseIO
 
 NONE_LABEL = "__null_dask_index__"
@@ -303,7 +303,7 @@ class ReadParquet(BlockwiseIO):
         return self._plan["divisions"]
 
     def dependencies(self):
-        return [IndexableArg(self._plan["parts"])]
+        return [BlockwiseArg(self._plan["parts"])]
 
     def _blockwise_subgraph(self):
         dep = self.dependencies()[0]._name

--- a/dask_match/io/parquet.py
+++ b/dask_match/io/parquet.py
@@ -299,9 +299,9 @@ class ReadParquet(BlockwiseIO):
     def _divisions(self):
         return self._plan["divisions"]
 
-    def _subgraph_dependencies(self):
+    def dependencies(self):
         return [MappedArg(self._plan["parts"])]
 
     def _blockwise_subgraph(self):
-        dep = self._subgraph_dependencies()[0]._name
+        dep = self.dependencies()[0]._name
         return {self._name: (self._plan["func"], dep)}

--- a/dask_match/io/parquet.py
+++ b/dask_match/io/parquet.py
@@ -12,7 +12,7 @@ from dask.dataframe.io.parquet.utils import _split_user_options
 from dask.utils import natural_sort_key
 from matchpy import CustomConstraint, Pattern, ReplacementRule, Wildcard
 
-from dask_match.core import EQ, GE, GT, LE, LT, NE, Filter, BlockwiseArg
+from dask_match.core import EQ, GE, GT, LE, LT, NE, BlockwiseArg, Filter
 from dask_match.io import BlockwiseIO
 
 NONE_LABEL = "__null_dask_index__"
@@ -305,6 +305,6 @@ class ReadParquet(BlockwiseIO):
     def dependencies(self):
         return [BlockwiseArg(self._plan["parts"])]
 
-    def _blockwise_subgraph(self):
+    def _blockwise_layer(self):
         dep = self.dependencies()[0]._name
         return {self._name: (self._plan["func"], dep)}

--- a/dask_match/io/parquet.py
+++ b/dask_match/io/parquet.py
@@ -66,6 +66,9 @@ class ReadParquet(BlockwiseIO):
         "kwargs": {},
     }
 
+    def __str__(self):
+        return f"{type(self).__name__}({self.path})"
+
     @property
     def engine(self):
         return get_engine("pyarrow")

--- a/dask_match/io/parquet.py
+++ b/dask_match/io/parquet.py
@@ -12,7 +12,7 @@ from dask.dataframe.io.parquet.utils import _split_user_options
 from dask.utils import natural_sort_key
 from matchpy import CustomConstraint, Pattern, ReplacementRule, Wildcard
 
-from dask_match.core import EQ, GE, GT, LE, LT, NE, Filter, MappedArg
+from dask_match.core import EQ, GE, GT, LE, LT, NE, Filter, IndexableArg
 from dask_match.io import BlockwiseIO
 
 NONE_LABEL = "__null_dask_index__"
@@ -300,7 +300,7 @@ class ReadParquet(BlockwiseIO):
         return self._plan["divisions"]
 
     def dependencies(self):
-        return [MappedArg(self._plan["parts"])]
+        return [IndexableArg(self._plan["parts"])]
 
     def _blockwise_subgraph(self):
         dep = self.dependencies()[0]._name

--- a/dask_match/io/tests/test_io.py
+++ b/dask_match/io/tests/test_io.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from dask.dataframe.utils import assert_eq
 
-from dask_match import optimize, read_parquet
+from dask_match import optimize, read_parquet, read_csv
 
 
 def _make_file(dir, format="parquet", df=None):
@@ -64,9 +64,13 @@ def test_optimize(tmpdir, input, expected):
     assert str(result.expr) == str(expected(fn).expr)
 
 
-def test_parquet_fusion(tmpdir):
-    fn = _make_file(tmpdir, format="parquet")
-    df = read_parquet(fn)
+@pytest.mark.parametrize("fmt", ["parquet", "csv"])
+def test_io_fusion(tmpdir, fmt):
+    fn = _make_file(tmpdir, format=fmt)
+    if fmt == "parquet":
+        df = read_parquet(fn)
+    else:
+        df = read_csv(fn)
     df2 = optimize(df[["a", "b"]] + 1, fuse=True)
 
     # All tasks should be fused for each partition

--- a/dask_match/reductions.py
+++ b/dask_match/reductions.py
@@ -1,6 +1,11 @@
 import pandas as pd
 import toolz
-from dask.dataframe.core import _concat, is_series_like, make_meta, meta_nonempty
+from dask.dataframe.core import (
+    _concat,
+    is_series_like,
+    make_meta,
+    meta_nonempty,
+)
 from dask.utils import M, apply
 from matchpy import Pattern, ReplacementRule, Wildcard
 

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -146,7 +146,6 @@ def test_columns_traverse_filters(df, ddf):
 
 
 def test_optimize_fusion(ddf):
-
     ddf2 = (ddf["x"] + ddf["y"]) - 1
     unfused = optimize(ddf2, fuse=False)
     fused = optimize(ddf2, fuse=True)
@@ -166,7 +165,7 @@ def test_optimize_fusion(ddf):
 
     # Check that we still get fusion
     # after a non-blockwise operation as well
-    fused_2 = optimize(ddf3 + 10 - 5, fuse=True)
+    fused_2 = optimize((ddf3 + 10) - 5, fuse=True)
     # The "+10 and -5" ops should get fused
     assert len(fused_2.dask) == len(fused.dask) + 1
 

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -218,6 +218,14 @@ def test_optimize_fusion_repeat(ddf):
     assert_eq(ser_fused, ser)
 
 
+def test_optimize_fusion_broadcast(ddf):
+    # Check fusion with broadcated reduction
+    ser = ((ddf["x"] + 1) + ddf["y"].sum()) + 1
+    ser_fused = optimize(ser, fuse=True)
+    assert_eq(ser_fused, ser)
+    assert len(ser_fused.dask) < len(ser.dask)
+
+
 def test_persist(df, ddf):
     a = ddf + 2
     b = a.persist()

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -224,10 +224,10 @@ def test_broadcast(df, ddf):
 
 def test_optimize_fusion_broadcast(ddf):
     # Check fusion with broadcated reduction
-    ser = ((ddf["x"] + 1) + ddf["y"].sum()) + 1
-    ser_fused = optimize(ser, fuse=True)
-    assert_eq(ser_fused, ser)
-    assert len(ser_fused.dask) < len(ser.dask)
+    result = ((ddf["x"] + 1) + ddf["y"].sum()) + 1
+    result_fused = optimize(result, fuse=True)
+    assert_eq(result_fused, result)
+    assert len(result_fused.dask) < len(result.dask)
 
 
 def test_persist(df, ddf):

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -223,6 +223,17 @@ def test_persist(df, ddf):
     assert_eq(b.y.sum(), (df + 2).y.sum())
 
 
+def test_persist_with_fusion(ddf):
+    # Check that fusion works after persisting
+    a = ddf + 2
+    b = a.persist()
+
+    c = (b.y + 1).sum()
+    c_fused = optimize(c, fuse=True)
+    assert_eq(c, c_fused)
+    assert len(c_fused.dask) < len(c.dask)
+
+
 def test_index(df, ddf):
     assert_eq(ddf.index, df.index)
     assert_eq(ddf.x.index, df.x.index)

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -145,9 +145,7 @@ def test_columns_traverse_filters(df, ddf):
     assert str(result) == str(expected)
 
 
-def test_optimize_fusion():
-    pdf = pd.DataFrame({"x": range(10), "y": range(10)})
-    ddf = from_pandas(pdf, npartitions=1)
+def test_optimize_fusion(ddf):
 
     ddf2 = (ddf["x"] + ddf["y"]) - 1
     unfused = optimize(ddf2, fuse=False)
@@ -165,6 +163,12 @@ def test_optimize_fusion():
 
     assert len(fused.dask) < len(unfused.dask)
     assert_eq(fused, unfused)
+
+    # Check that we still get fusion
+    # after a non-blockwise operation as well
+    fused_2 = optimize(ddf3 + 10 - 5, fuse=True)
+    # The "+10 and -5" ops should get fused
+    assert len(fused_2.dask) == len(fused.dask) + 1
 
 
 def test_persist(df, ddf):

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -145,6 +145,16 @@ def test_columns_traverse_filters(df, ddf):
     assert str(result) == str(expected)
 
 
+def test_optimize():
+    pdf = pd.DataFrame({"x": range(10), "y": range(10)})
+    ddf = from_pandas(pdf, npartitions=1)
+    result = optimize(ddf[ddf.x > 5])
+    
+    import pdb; pdb.set_trace()
+    pass
+
+
+
 def test_persist(df, ddf):
     a = ddf + 2
     b = a.persist()

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -170,12 +170,11 @@ def test_optimize_fusion(ddf):
     assert len(fused_2.dask) == len(fused.dask) + 1
 
 
-@pytest.mark.parametrize("persist", [True, False])
-def test_optimize_fusion_many(ddf, persist):
+def test_optimize_fusion_many(ddf):
     # Test that many `Blockwise`` operations,
     # originating from various IO operations,
     # can all be fused together
-    ddfa = ddf.persist() if persist else ddf
+    ddfa = ddf
     ddfb = from_pandas(pd.DataFrame({"a": range(100)}), ddf.npartitions)
 
     ddf2a = ddfa[["x"]] + 1
@@ -190,13 +189,7 @@ def test_optimize_fusion_many(ddf, persist):
     ser = (sera + serb) + 1
     unfused = optimize(ser, fuse=False)
     fused = optimize(ser, fuse=True)
-    if persist:
-        # Can't fuse persisted graph, but everything
-        # after should be fused
-        assert len(fused.dask) == ddf.npartitions * 2
-    else:
-        # Everything should be fused
-        assert len(fused.dask) == ddf.npartitions
+    assert len(fused.dask) == ddf.npartitions
     assert_eq(fused, unfused)
 
 

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -145,11 +145,16 @@ def test_columns_traverse_filters(df, ddf):
     assert str(result) == str(expected)
 
 
-def test_optimize():
+def test_optimize_fusion():
     pdf = pd.DataFrame({"x": range(10), "y": range(10)})
     ddf = from_pandas(pdf, npartitions=1)
-    result = optimize(((ddf["x"] + ddf["y"]) - 1).sum())
-    result.compute()
+    ddf2 = ((ddf["x"] + ddf["y"]) - 1).sum()
+    unfused = optimize(ddf2, fuse=False)
+    fused = optimize(ddf2, fuse=True)
+
+    # All tasks should be fused for each partition
+    assert len(unfused.dask) > len(fused.dask)
+    assert_eq(fused, unfused)
 
 
 def test_persist(df, ddf):

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -148,7 +148,7 @@ def test_columns_traverse_filters(df, ddf):
 def test_optimize():
     pdf = pd.DataFrame({"x": range(10), "y": range(10)})
     ddf = from_pandas(pdf, npartitions=1)
-    result = optimize(ddf[ddf.x > 5])
+    result = optimize(((ddf["x"] + ddf["y"]) - 1).sum())
     result.compute()
 
 

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -139,7 +139,7 @@ def test_repr(ddf):
 
 
 def test_columns_traverse_filters(df, ddf):
-    result = optimize(ddf[ddf.x > 5].y)
+    result = optimize(ddf[ddf.x > 5].y, fuse=False)
     expected = ddf.y[ddf.x > 5]
 
     assert str(result) == str(expected)
@@ -149,10 +149,7 @@ def test_optimize():
     pdf = pd.DataFrame({"x": range(10), "y": range(10)})
     ddf = from_pandas(pdf, npartitions=1)
     result = optimize(ddf[ddf.x > 5])
-    
-    import pdb; pdb.set_trace()
-    pass
-
+    result.compute()
 
 
 def test_persist(df, ddf):

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -301,3 +301,13 @@ def test_from_pandas(df):
     ddf = from_pandas(df, npartitions=3)
     assert ddf.npartitions == 3
     assert "from-pandas" in ddf._name
+
+
+def test_copy(ddf):
+    original = ddf.copy()
+    columns = tuple(original.columns)
+
+    ddf["z"] = ddf.x + ddf.y
+
+    assert tuple(original.columns) == columns
+    assert "z" not in original.columns

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -18,9 +18,7 @@ def ddf(df):
     yield from_pandas(df, npartitions=10)
 
 
-def test_del():
-    df = pd.DataFrame({"x": range(100), "y": range(100)})
-    ddf = from_pandas(df, npartitions=10)
+def test_del(df, ddf):
     df = df.copy()
 
     # Check __delitem__
@@ -29,9 +27,7 @@ def test_del():
     assert_eq(df, ddf)
 
 
-def test_setitem():
-    df = pd.DataFrame({"x": range(100), "y": range(100)})
-    ddf = from_pandas(df, npartitions=10)
+def test_setitem(df, ddf):
     df = df.copy()
 
     ddf["z"] = ddf.x + ddf.y

--- a/dask_match/tests/test_fusion.py
+++ b/dask_match/tests/test_fusion.py
@@ -1,0 +1,103 @@
+import pandas as pd
+import pytest
+from dask.dataframe.utils import assert_eq
+
+from dask_match import from_pandas, optimize
+
+
+@pytest.fixture
+def df():
+    df = pd.DataFrame({"x": range(100)})
+    df["y"] = df.x * 10.0
+    yield df
+
+
+@pytest.fixture
+def ddf(df):
+    yield from_pandas(df, npartitions=10)
+
+
+def test_simple(ddf):
+    out = (ddf["x"] + ddf["y"]) - 1
+    unfused = optimize(out, fuse=False)
+    fused = optimize(out, fuse=True)
+
+    # Should only get one task per partition
+    assert len(fused.dask) == ddf.npartitions
+    assert_eq(fused, unfused)
+
+
+def test_with_non_fusable_on_top(ddf):
+    out = (ddf["x"] + ddf["y"] - 1).sum()
+    unfused = optimize(out, fuse=False)
+    fused = optimize(out, fuse=True)
+
+    assert len(fused.dask) < len(unfused.dask)
+    assert_eq(fused, unfused)
+
+    # Check that we still get fusion
+    # after a non-blockwise operation as well
+    fused_2 = optimize((out + 10) - 5, fuse=True)
+    assert len(fused_2.dask) == len(fused.dask) + 1  # only one more task
+
+
+def test_optimize_fusion_many():
+    # Test that many `Blockwise`` operations,
+    # originating from various IO operations,
+    # can all be fused together
+    a = from_pandas(pd.DataFrame({"x": range(100), "y": range(100)}), 10)
+    b = from_pandas(pd.DataFrame({"a": range(100)}), 10)
+
+    # some generic elemwise operations
+    aa = a[["x"]] + 1
+    aa["a"] = a["y"] + a["x"]
+    aa["b"] = aa["x"] + 2
+    series_a = aa[a["x"] > 1]["b"]
+
+    bb = b[["a"]] + 1
+    bb["b"] = b["a"] + b["a"]
+    series_b = bb[b["a"] > 1]["b"]
+
+    result = (series_a + series_b) + 1
+    fused = optimize(result, fuse=True)
+    unfused = optimize(result, fuse=False)
+    assert fused.npartitions == a.npartitions
+    assert len(fused.dask) == fused.npartitions
+    assert_eq(fused, unfused)
+
+
+def test_optimize_fusion_repeat(ddf):
+    # Test that we can optimize a collection
+    # more than once, and fusion still works
+
+    original = ddf.copy()
+
+    # some generic elemwise operations
+    ddf["x"] += 1
+    ddf["z"] = ddf.y
+    ddf += 2
+
+    # repeatedly call optimize after doing new fusable things
+    fused = optimize(optimize(optimize(ddf) + 2).x)
+
+    assert len(fused.dask) == fused.npartitions == original.npartitions
+    assert_eq(fused, ddf.x + 2)
+
+
+def test_optimize_fusion_broadcast(ddf):
+    # Check fusion with broadcated reduction
+    result = ((ddf["x"] + 1) + ddf["y"].sum()) + 1
+    fused = optimize(result)
+
+    assert_eq(fused, result)
+    assert len(fused.dask) < len(result.dask)
+
+
+def test_persist_with_fusion(ddf):
+    # Check that fusion works after persisting
+    ddf = (ddf + 2).persist()
+    out = (ddf.y + 1).sum()
+    fused = optimize(out)
+
+    assert_eq(out, fused)
+    assert len(fused.dask) < len(out.dask)


### PR DESCRIPTION
This PR repurposes most of the code in #11 to enable `Blockwise`/`IO` fusion as a distinct optimization pass. Note that this iteration is designed to compose and fuse arbitrary groups of `Fusable` `Expr`s where no members of the group have external "dependents" (e.g. diamond-shaped sub-graphs).

Supersedes #11
Closes #9 

**TODO**:
- [x] Clean up and organize new utilities