### PR TITLE
Use `ProjectPartitions` to enable high-level culling

### DIFF
--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -110,9 +110,10 @@ class FrameBase(DaskMethodsMixin):
 
     def head(self, n=5, compute=True):
         # We special-case head because matchpy uses 'head' as a special term
-        from dask_match.core import Head
+        from dask_match.core import Head, ProjectPartitions
 
-        out = new_collection(Head(self.expr, n=n))
+        # We use ProjectPartitions to facilitate Expr optimizations
+        out = new_collection(Head(ProjectPartitions(self.expr, [0]), n=n))
         if compute:
             out = out.compute()
         return out

--- a/dask_match/io/tests/test_io.py
+++ b/dask_match/io/tests/test_io.py
@@ -64,7 +64,7 @@ def test_optimize(tmpdir, input, expected):
     assert str(result.expr) == str(expected(fn).expr)
 
 
-def test_head_partition_culling(tmpdir):
+def test_head_graph_culling(tmpdir):
     fn = _make_file(tmpdir, format="parquet")
     ddf = read_parquet(fn)
     result = ddf.head(compute=False)

--- a/dask_match/io/tests/test_io.py
+++ b/dask_match/io/tests/test_io.py
@@ -64,6 +64,15 @@ def test_optimize(tmpdir, input, expected):
     assert str(result.expr) == str(expected(fn).expr)
 
 
+def test_head_partition_culling(tmpdir):
+    fn = _make_file(tmpdir, format="parquet")
+    ddf = read_parquet(fn)
+    result = ddf.head(compute=False)
+
+    assert len(optimize(result).dask) == 2
+    assert_eq(optimize(result), result)
+
+
 def test_predicate_pushdown(tmpdir):
     from dask_match.io import ReadParquet
 

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -177,8 +177,7 @@ def test_head_graph_culling(ddf):
     assert_eq(optimize(result), result)
 
     # Check that the partition selection
-    # is pushed down through multiple
-    # Blockwise operations
+    # is pushed down through Blockwise
     result_2 = (ddf + 1).head(compute=False)
     assert len(optimize(result_2).dask) < ddf.npartitions
     assert_eq(optimize(result_2), result_2)

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -167,3 +167,18 @@ def test_head(df, ddf):
     assert_eq(ddf.head(compute=False, n=7), df.head(n=7))
 
     assert ddf.head(compute=False).npartitions == 1
+
+
+def test_head_graph_culling(ddf):
+    # Check that from_pandas avoids
+    # producing unnecessary tasks
+    result = ddf.head(compute=False)
+    assert len(optimize(result).dask) < ddf.npartitions
+    assert_eq(optimize(result), result)
+
+    # Check that the partition selection
+    # is pushed down through multiple
+    # Blockwise operations
+    result_2 = (ddf + 1).head(compute=False)
+    assert len(optimize(result_2).dask) < ddf.npartitions
+    assert_eq(optimize(result_2), result_2)


### PR DESCRIPTION
This PR implements `ProjectPartitions` and uses it within `head` to avoid the need for low-level culling. This was originally an experiment meant to explore @mrocklin's thoughts in [this comment](https://github.com/mrocklin/dask-match/pull/11#issuecomment-1494884001).

I do think this work demonstrates that low-level culling is probably unnecessary.  That is, It seems relatively easy to push down `ProjectPartitions` through `Blockwise` expressions, and then only non-`Blockwise` expressions need to support something like `output_partitions_rule` to avoid the materialization of unnecessary tasks.