### PR TITLE
Use type name for name if no operator present in Blockwise

### DIFF
--- a/dask_match/expr.py
+++ b/dask_match/expr.py
@@ -422,7 +422,11 @@ class Blockwise(Expr):
 
     @functools.cached_property
     def _name(self):
-        return funcname(self.operation) + "-" + tokenize(*self.operands)
+        if self.operation:
+            head = funcname(self.operation)
+        else:
+            head = funcname(type(self)).lower()
+        return head + "-" + tokenize(*self.operands)
 
     def _blockwise_arg(self, arg, i):
         """Return a Blockwise-task argument"""

--- a/dask_match/io/io.py
+++ b/dask_match/io/io.py
@@ -1,7 +1,4 @@
-import functools
 import math
-
-from dask.base import tokenize
 
 from dask_match.expr import Blockwise, Expr
 
@@ -44,10 +41,6 @@ class FromPandas(BlockwiseIO):
 
     _parameters = ["frame", "npartitions"]
     _defaults = {"npartitions": 1}
-
-    @functools.cached_property
-    def _name(self):
-        return "from-pandas-" + tokenize(self.frame, self.npartitions)
 
     @property
     def _meta(self):

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -230,7 +230,7 @@ def test_substitute(df):
 def test_from_pandas(pdf):
     df = from_pandas(pdf, npartitions=3)
     assert df.npartitions == 3
-    assert "from-pandas" in df._name
+    assert "pandas" in df._name
 
 
 def test_copy(pdf, df):


### PR DESCRIPTION
Previously all of the BlockwiseIO classes had the key prefix "None" because self.operator was not defined.