### PR TITLE
Improve culling

### DIFF
--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -118,8 +118,7 @@ class FrameBase(DaskMethodsMixin):
 
     def head(self, n=5, compute=True):
         # We special-case head because matchpy uses 'head' as a special term
-
-        out = new_collection(expr.Head(self.expr, n=n))
+        out = new_collection(expr.Head(expr.Partitions(self.expr, [0]), n=n))
         if compute:
             out = out.compute()
         return out

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -264,6 +264,10 @@ def optimize(collection, fuse=True):
     return new_collection(expr.optimize(collection.expr, fuse=fuse))
 
 
+def simplify(collection):
+    return new_collection(expr.simplify(collection.expr)[0])
+
+
 def from_pandas(*args, **kwargs):
     from dask_match.io.io import FromPandas
 

--- a/dask_match/io/csv.py
+++ b/dask_match/io/csv.py
@@ -4,8 +4,8 @@ from dask_match.io.io import BlockwiseIO
 
 
 class ReadCSV(BlockwiseIO):
-    _parameters = ["filename", "usecols", "header"]
-    _defaults = {"usecols": None, "header": "infer"}
+    _parameters = ["filename", "usecols", "header", "_take_partitions"]
+    _defaults = {"usecols": None, "header": "infer", "_take_partitions": None}
 
     @functools.cached_property
     def _ddf(self):
@@ -35,4 +35,6 @@ class ReadCSV(BlockwiseIO):
         return next(iter(dsk.values()))[0]
 
     def _task(self, index: int):
+        if self._take_partitions is not None:
+            index = self._take_partitions[index]
         return (self._io_func, self._tasks[index][1])

--- a/dask_match/io/tests/test_io.py
+++ b/dask_match/io/tests/test_io.py
@@ -2,9 +2,11 @@ import os
 
 import pandas as pd
 import pytest
+import dask.dataframe as dd
 from dask.dataframe.utils import assert_eq
 
-from dask_match import optimize, read_parquet, read_csv
+from dask_match import from_pandas, optimize, read_parquet, read_csv
+from dask_match.utils import _check_take_partitions
 
 
 def _make_file(dir, format="parquet", df=None):
@@ -93,7 +95,7 @@ def test_predicate_pushdown(tmpdir):
     fn = _make_file(tmpdir, format="parquet", df=original)
     df = read_parquet(fn)
     assert_eq(df, original)
-    x = df[df.a == 5][df.c > 20]["b"]
+    x = df[df.a == 5][df.c > 20][["b"]]
     y = optimize(x)
     assert isinstance(y.expr, ReadParquet)
     assert ("a", "==", 5) in y.expr.operand("filters") or (
@@ -109,3 +111,29 @@ def test_predicate_pushdown(tmpdir):
     assert list(y_result.columns) == ["b"]
     assert len(y_result["b"]) == 6
     assert all(y_result["b"] == 4)
+
+
+@pytest.mark.parametrize("fmt", ["parquet", "csv", "pandas"])
+def test_io_culling(tmpdir, fmt):
+    pdf = pd.DataFrame({c: range(10) for c in "abcde"})
+    if fmt == "parquet":
+        dd.from_pandas(pdf, 2).to_parquet(tmpdir)
+        df = read_parquet(tmpdir)
+    elif fmt == "parquet":
+        dd.from_pandas(pdf, 2).to_csv(tmpdir)
+        df = read_csv(tmpdir + "/*")
+    else:
+        df = from_pandas(pdf, 2)
+    df = (df[["a", "b"]] + 1).partitions[1]
+    df2 = optimize(df)
+
+    # All tasks should be fused for the single output partition
+    assert df2.npartitions == 1
+    assert len(df2.dask) == df2.npartitions
+    expected = pdf.iloc[5:][["a", "b"]] + 1
+    assert_eq(df2, expected, check_index=False)
+
+    # Check that we still get culling without fusion
+    df3 = optimize(df, fuse=False)
+    _check_take_partitions(df3.expr, [1])
+    assert_eq(df3, expected, check_index=False)

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -255,6 +255,11 @@ def test_partitions(pdf, df):
     assert isinstance(out.expr, expr.Add)
     assert isinstance(out.expr.left, expr.Partitions)
 
+    # Check culling
+    out = optimize(df.partitions[1])
+    assert len(out.dask) == 1
+    assert_eq(out, pdf.iloc[10:20])
+
 
 def test_column_getattr(df):
     df = df.expr

--- a/dask_match/utils.py
+++ b/dask_match/utils.py
@@ -1,0 +1,10 @@
+def _check_take_partitions(expr, partitions):
+    # Test utility to check culling.
+    # Checks that "_take_partitions" is set to the
+    # expected value for all expressions defining
+    # a "_take_partitions" parameter
+    for dep in expr.dependencies():
+        _check_take_partitions(dep, partitions)
+    if "_take_partitions" in expr._parameters:
+        assert expr._take_partitions == partitions
+    return


### PR DESCRIPTION
While playing around with `pprint` and `dask.visualize`, I discovered a lot of fragile behavior when combining various optimizations with `Head`/`Partitions` (i.e. fusion and column projection).  After a lot of experimentation, I found that the simplest way to allow all three optimizations to work smoothly together is to do the following:

1.  Add special logic in `Expr` for the case that an optional `_take_partitions` parameter is defined.
2. Change the `head` logic to use `Head(Partitions(...))`
3. Change `Head` to inherit from `Blockwise`. The purpose of this expression is now to return the first `n` rows of every partition.

#### Meaning of `_take_partitions`:

When an `Expr` subclass exposes "_take_partitions" in its `_parameters` list, that subclass (`cls`) is ensuring that the behavior of `cls(*operands, _take_partitions=[0])` is equivalent to that of `Partitions(cls(*operands), [0])`.

#### Why we want `Partitions` to "simplify away:

Optimizations like fusion, column-projection and predicate pushdown are all "blocked" when a `Partitions`/`Head` operation follows a `BlockwiseIO` expression. The only way to "unblock" these optimizations is if the necessary expressions can "absorb" the `Partitions` logic.

#### why we probably want `Expr` to be aware of `_take_partitions`:

This PR only adds `_take_partitions` to a few IO layers. However, we will eventually want to add the same logic for many other expressions that are likely to precede `Partitions` (e.g. joins and shuffles).

### Example of current behavior

```python
from dask_match import from_pandas, optimize
from dask.base import visualize
import pandas as pd

ddf = from_pandas(
    pd.DataFrame({"x": range(30), "id": [99, 1000, 1001] * 10}),
    npartitions=3,
)
s = (ddf["x"][ddf["id"] > 1000] + 1).head(compute=False)
optimize(s, fuse=False).pprint()
```
```
Add:1
  Head:
    Filter:
      Projection:'x'
        FromPandas: npartitions=3
      GT:1000
        Projection:'id'
          FromPandas: npartitions=3
```
```python
visualize(s, filename=None, optimize_graph=False, orientation="left", size="8")
```
![Screen Shot 2023-04-18 at 1 41 36 PM](https://user-images.githubusercontent.com/20461013/232877453-fec2c64f-3b66-4df9-bd81-00d103d2f31c.png)

```python
visualize(optimize(s), filename=None, optimize_graph=False, orientation="left", size="8")
```

![Screen Shot 2023-04-18 at 2 00 17 PM](https://user-images.githubusercontent.com/20461013/232878624-b8325c30-4c2c-49ca-bba8-f6ce2a00daa8.png)


### Example of NEW behavior

```python
optimize(s, fuse=False).pprint()
```
```
Add:1
  Head:
    Filter:
      Projection:'x'
        FromPandas: npartitions=3 _take_partitions=[0]
      GT:1000
        Projection:'id'
          FromPandas: npartitions=3 _take_partitions=[0]
```
```python
visualize(s, filename=None, optimize_graph=False, orientation="left", size="8")
```
![Screen Shot 2023-04-18 at 1 57 31 PM](https://user-images.githubusercontent.com/20461013/232877938-aadc0541-8cdc-47c3-ba6d-5261b2ccad3b.png)

```python
visualize(optimize(s), filename=None, optimize_graph=False, orientation="left", size="8")
```
![Screen Shot 2023-04-18 at 1 58 11 PM](https://user-images.githubusercontent.com/20461013/232878181-de4f971b-ae17-4c67-be29-2f57cfa5cba6.png)


