### PR TITLE
Add abstract Mean operation

### DIFF
--- a/dask_match/expr.py
+++ b/dask_match/expr.py
@@ -306,7 +306,7 @@ class Expr(Operation, metaclass=_ExprMeta):
         return Sum(self, skipna, numeric_only, min_count)
 
     def mean(self, skipna=True, numeric_only=None, min_count=0):
-        return self.sum(skipna=skipna) / self.count()
+        return Mean(self, skipna=skipna, numeric_only=numeric_only)
 
     def max(self, skipna=True, numeric_only=None, min_count=0):
         return Max(self, skipna, numeric_only, min_count)
@@ -1080,4 +1080,4 @@ class Fused(Blockwise):
 
 
 from dask_match.io import BlockwiseIO
-from dask_match.reductions import Count, Max, Min, Mode, Size, Sum
+from dask_match.reductions import Count, Max, Mean, Min, Mode, Size, Sum

--- a/dask_match/reductions.py
+++ b/dask_match/reductions.py
@@ -237,6 +237,23 @@ class Size(Reduction):
             return Len(self.frame)
 
 
+class Mean(Reduction):
+    _parameters = ["frame", "skipna", "numeric_only"]
+    _defaults = {"skipna": True, "numeric_only": None}
+
+    @property
+    def _meta(self):
+        return (
+            self.frame._meta.sum(skipna=self.skipna, numeric_only=self.numeric_only) / 2
+        )
+
+    def simplify(self):
+        return (
+            self.frame.sum(skipna=self.skipna, numeric_only=self.numeric_only)
+            / self.frame.count()
+        )
+
+
 class Count(Reduction):
     _parameters = ["frame", "numeric_only"]
     split_every = 16


### PR DESCRIPTION
This came up in conversation with @jorisvandenbossche

It's a good example of an operation that doesn't have any concrete implementation, but instead optimizes itself down to other operations for execution.  This is our approach with shuffles, but this is probably easier to explain.