### PR TITLE
Add basic `MapPartitions` support

### DIFF
--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -13,6 +13,7 @@ from fsspec.utils import stringify_path
 from tlz import first
 
 from dask_match import expr
+from dask_match.expr import no_default
 
 #
 # Utilities to wrap Expr API
@@ -152,6 +153,36 @@ class FrameBase(DaskMethodsMixin):
         >>> df.partitions[::10]
         """
         return IndexCallable(self._partitions)
+
+
+    def map_partitions(
+        self,
+        func,
+        *args,
+        meta=no_default,
+        enforce_metadata=True,
+        transform_divisions=False,
+        align_dataframes=False,
+        **kwargs,
+    ):
+        new_expr = expr.MapPartitions(
+            self.expr,
+            func,
+            meta,
+            {
+                "enforce_metadata": enforce_metadata,
+                "transform_divisions": transform_divisions,
+                "align_dataframes": align_dataframes,
+            },
+            kwargs,
+            *[
+                arg.expr
+                if isinstance(arg, FrameBase)
+                else arg
+                for arg in args
+            ],
+        )
+        return new_collection(new_expr)
 
 
 # Add operator attributes

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -154,7 +154,6 @@ class FrameBase(DaskMethodsMixin):
         """
         return IndexCallable(self._partitions)
 
-
     def map_partitions(
         self,
         func,
@@ -175,12 +174,7 @@ class FrameBase(DaskMethodsMixin):
                 "align_dataframes": align_dataframes,
             },
             kwargs,
-            *[
-                arg.expr
-                if isinstance(arg, FrameBase)
-                else arg
-                for arg in args
-            ],
+            *[arg.expr if isinstance(arg, FrameBase) else arg for arg in args],
         )
         return new_collection(new_expr)
 

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -160,10 +160,44 @@ class FrameBase(DaskMethodsMixin):
         *args,
         meta=no_default,
         enforce_metadata=True,
-        transform_divisions=False,
+        transform_divisions=True,
         align_dataframes=False,
         **kwargs,
     ):
+        """Apply a Python function to each partition
+
+        Parameters
+        ----------
+        func : function
+            Function applied to each partition.
+        args, kwargs :
+            Arguments and keywords to pass to the function. Arguments and
+            keywords may contain ``FrameBase`` or regular python objects.
+            DataFrame-like args (both dask and pandas) must have the same
+            number of partitions as ``self` or comprise a single partition.
+            Key-word arguments, Single-partition arguments, and general
+            python-object argments will be broadcasted to all partitions.
+        enforce_metadata : bool, default True
+            Whether to enforce at runtime that the structure of the DataFrame
+            produced by ``func`` actually matches the structure of ``meta``.
+            This will rename and reorder columns for each partition, and will
+            raise an error if this doesn't work, but it won't raise if dtypes
+            don't match.
+        transform_divisions : bool, default True
+            Whether to apply the function onto the divisions and apply those
+            transformed divisions to the output.
+        meta : Any, optional
+            DataFrame object representing the schema of the expected result.
+        """
+
+        if align_dataframes:
+            # TODO: Handle alignment?
+            # Perhaps we only handle the case that all `Expr` operands
+            # have the same number of partitions or can be broadcasted
+            # within `MapPartitions`. If so, the `map_partitions` API
+            # will need to call `Repartition` on operands that are not
+            # aligned with `self.expr`.
+            raise NotImplementedError()
         new_expr = expr.MapPartitions(
             self.expr,
             func,
@@ -171,7 +205,6 @@ class FrameBase(DaskMethodsMixin):
             {
                 "enforce_metadata": enforce_metadata,
                 "transform_divisions": transform_divisions,
-                "align_dataframes": align_dataframes,
             },
             kwargs,
             *[arg.expr if isinstance(arg, FrameBase) else arg for arg in args],

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -202,10 +202,8 @@ class FrameBase(DaskMethodsMixin):
             self.expr,
             func,
             meta,
-            {
-                "enforce_metadata": enforce_metadata,
-                "transform_divisions": transform_divisions,
-            },
+            enforce_metadata,
+            transform_divisions,
             kwargs,
             *[arg.expr if isinstance(arg, FrameBase) else arg for arg in args],
         )

--- a/dask_match/expr.py
+++ b/dask_match/expr.py
@@ -11,7 +11,7 @@ import toolz
 from dask.base import normalize_token, tokenize
 from dask.core import ishashable
 from dask.dataframe import methods
-from dask.dataframe.core import is_dataframe_like
+from dask.dataframe.core import is_dataframe_like, apply_and_enforce
 from dask.utils import M, apply, funcname
 from matchpy import (
     Arity,
@@ -25,6 +25,8 @@ from matchpy import (
 from matchpy.expressions.expressions import _OperationMeta
 
 replacement_rules = []
+
+no_default = "__no_default__"
 
 
 class _ExprMeta(_OperationMeta):
@@ -498,6 +500,73 @@ class Blockwise(Expr):
             return (apply, self.operation, args, self._kwargs)
         else:
             return (self.operation,) + args
+
+
+class MapPartitions(Blockwise):
+
+    _parameters = [
+        "frame",
+        "func",
+        "meta",
+        "options",
+        "kwargs",
+    ]
+
+    @property
+    def args(self):
+        return [self.frame] + self.operands[len(self._parameters):]
+    
+    @property
+    def enforce_metadata(self):
+        return self.options.get("enforce_metadata", True)
+    
+    @property
+    def transform_divisions(self):
+        return self.options.get("transform_divisions", True)
+    
+    @property
+    def align_dataframes(self):
+        return self.options.get("align_dataframes", True)
+
+    @functools.cached_property
+    def _meta(self):
+        from dask.dataframe.core import _get_meta_map_partitions
+
+        meta = self.operand("meta")
+        args = [arg._meta if isinstance(arg, Expr) else arg for arg in self.args]
+        return _get_meta_map_partitions(args, [], self.func, self.kwargs, meta, None)
+
+    def _divisions(self):
+        from dask.dataframe.core import _get_divisions_map_partitions
+
+        dfs = [arg for arg in self.args if isinstance(arg, Expr)]
+        return _get_divisions_map_partitions(
+            self.align_dataframes,
+            self.transform_divisions,
+            dfs,
+            self.func,
+            self.args,
+            self.kwargs,
+        )
+    
+    def _task(self, index: int):
+        args = [self._blockwise_arg(op, index) for op in self.args]
+        if self.enforce_metadata:
+            kwargs = self.kwargs.copy()
+            kwargs.update(
+                {
+                    "_func": self.func,
+                    "_meta": self._meta,
+                }
+            )
+            return (apply, apply_and_enforce, args, kwargs)
+        else:
+            return (
+                apply,
+                self.func,
+                args,
+                self.kwargs,
+            )
 
 
 class Elemwise(Blockwise):

--- a/dask_match/expr.py
+++ b/dask_match/expr.py
@@ -503,7 +503,6 @@ class Blockwise(Expr):
 
 
 class MapPartitions(Blockwise):
-
     _parameters = [
         "frame",
         "func",
@@ -514,16 +513,16 @@ class MapPartitions(Blockwise):
 
     @property
     def args(self):
-        return [self.frame] + self.operands[len(self._parameters):]
-    
+        return [self.frame] + self.operands[len(self._parameters) :]
+
     @property
     def enforce_metadata(self):
         return self.options.get("enforce_metadata", True)
-    
+
     @property
     def transform_divisions(self):
         return self.options.get("transform_divisions", True)
-    
+
     @property
     def align_dataframes(self):
         return self.options.get("align_dataframes", True)
@@ -548,7 +547,7 @@ class MapPartitions(Blockwise):
             self.args,
             self.kwargs,
         )
-    
+
     def _task(self, index: int):
         args = [self._blockwise_arg(op, index) for op in self.args]
         if self.enforce_metadata:

--- a/dask_match/expr.py
+++ b/dask_match/expr.py
@@ -512,7 +512,8 @@ class MapPartitions(Blockwise):
         "frame",
         "func",
         "meta",
-        "options",
+        "enforce_metadata",
+        "transform_divisions",
         "kwargs",
     ]
 
@@ -523,14 +524,6 @@ class MapPartitions(Blockwise):
     @property
     def args(self):
         return [self.frame] + self.operands[len(self._parameters) :]
-
-    @property
-    def enforce_metadata(self):
-        return self.options.get("enforce_metadata", True)
-
-    @property
-    def transform_divisions(self):
-        return self.options.get("transform_divisions", True)
 
     @functools.cached_property
     def _meta(self):

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -319,5 +319,18 @@ def test_simple_graphs(df):
 
 
 def test_map_partitions(df):
-    df2 = df.map_partitions(lambda x: x + 1)
-    assert_eq(df2, df + 1)
+    def combine_x_y(x, y, foo=None):
+        assert foo == "bar"
+        return x + y
+
+    df2 = df.map_partitions(combine_x_y, df + 1, foo="bar")
+    assert_eq(df2, df + (df + 1))
+
+
+def test_map_partitions_broadcast(df):
+    def combine_x_y(x, y, val, foo=None):
+        assert foo == "bar"
+        return x + y + val
+
+    df2 = df.map_partitions(combine_x_y, df["x"].sum(), 123, foo="bar")
+    assert_eq(df2, df + df["x"].sum() + 123)

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -316,3 +316,8 @@ def test_simple_graphs(df):
     graph = expr.__dask_graph__()
 
     assert graph[(expr._name, 0)] == (operator.add, (df.expr._name, 0), 1)
+
+
+def test_map_partitions(df):
+    df2 = df.map_partitions(lambda x: x + 1)
+    assert_eq(df2, df + 1)


### PR DESCRIPTION
While thinking through what we need for `Merge` and `Groupby`, I realized that we will typically want to decompose these abstract expressions into some combination of `ApplyConcatApply`, `Shuffle`, `Repartition`,  and `MapPartitions`. This PR adds basic functionality for the `MapPartitions` component.