### PR TITLE
Add `npartitions` and `divisions`-based repartitioning

### DIFF
--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -210,24 +210,36 @@ class FrameBase(DaskMethodsMixin):
         )
         return new_collection(new_expr)
 
-    def repartition(self, npartitions=None):
+    def repartition(self, npartitions=None, divisions=None, force=False):
         """Repartition a collection
+
+        Exactly one of `divisions` or `npartitions` should be specified.
+        A ``ValueError`` will be raised when that is not the case.
 
         Parameters
         ----------
-
         npartitions : int, optional
             Approximate number of partitions of output. The number of
             partitions used may be slightly lower than npartitions depending
             on data distribution, but will never be higher.
+        divisions : list, optional
+            The "dividing lines" used to split the dataframe into partitions.
+            For ``divisions=[0, 10, 50, 100]``, there would be three output partitions,
+            where the new index contained [0, 10), [10, 50), and [50, 100), respectively.
+            See https://docs.dask.org/en/latest/dataframe-design.html#partitions.
+        force : bool, default False
+            Allows the expansion of the existing divisions.
+            If False then the new divisions' lower and upper bounds must be
+            the same as the old divisions'.
         """
 
-        if npartitions is None:
-            # TODO: Support `divisions=`
-            raise ValueError("Please provide an ``npartitions=`` keyword argument.")
+        if sum([divisions is not None, npartitions is not None]) != 1:
+            raise ValueError(
+                "Please provide exactly one of the ``npartitions=`` or "
+                "``divisions=`` keyword arguments."
+            )
 
-        new_divisions = None
-        return new_collection(Repartition(self.expr, npartitions, new_divisions))
+        return new_collection(Repartition(self.expr, npartitions, divisions, force))
 
 
 # Add operator attributes

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -224,14 +224,10 @@ class FrameBase(DaskMethodsMixin):
 
         if npartitions is None:
             # TODO: Support `divisions=`
-            raise ValueError(
-                "Please provide an ``npartitions=`` keyword argument."
-            )
+            raise ValueError("Please provide an ``npartitions=`` keyword argument.")
 
         new_divisions = None
-        return new_collection(
-            Repartition(self.expr, npartitions, new_divisions)
-        )
+        return new_collection(Repartition(self.expr, npartitions, new_divisions))
 
 
 # Add operator attributes

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -14,6 +14,7 @@ from tlz import first
 
 from dask_match import expr
 from dask_match.expr import no_default
+from dask_match.repartition import Repartition
 
 #
 # Utilities to wrap Expr API
@@ -208,6 +209,29 @@ class FrameBase(DaskMethodsMixin):
             *[arg.expr if isinstance(arg, FrameBase) else arg for arg in args],
         )
         return new_collection(new_expr)
+
+    def repartition(self, npartitions=None):
+        """Repartition a collection
+
+        Parameters
+        ----------
+
+        npartitions : int, optional
+            Approximate number of partitions of output. The number of
+            partitions used may be slightly lower than npartitions depending
+            on data distribution, but will never be higher.
+        """
+
+        if npartitions is None:
+            # TODO: Support `divisions=`
+            raise ValueError(
+                "Please provide an ``npartitions=`` keyword argument."
+            )
+
+        new_divisions = None
+        return new_collection(
+            Repartition(self.expr, npartitions, new_divisions)
+        )
 
 
 # Add operator attributes

--- a/dask_match/repartition.py
+++ b/dask_match/repartition.py
@@ -83,11 +83,12 @@ class Repartition(Expr):
             raise NotImplementedError()
 
     def _simplify_up(self, parent):
-        # Move filter or column projection before repartitioning
-        if isinstance(parent, (Filter, Projection)) and not isinstance(
-            parent.operands[1], Expr
-        ):
-            op = type(parent)(self.frame, *parent.operands[1:])
+        # Reorder with column projection
+        if isinstance(parent, Projection):
+            return type(self)(self.frame[parent.columns], *self.operands[1:])
+        # Reorder with filter
+        if isinstance(parent, Filter) and not isinstance(parent.predicate, Expr):
+            op = type(parent)(self.frame, parent.predicate)
             return type(self)(op, *self.operands[1:])
 
 

--- a/dask_match/repartition.py
+++ b/dask_match/repartition.py
@@ -1,17 +1,23 @@
 import functools
 from operator import getitem
+from pprint import pformat
 
 import pandas as pd
+import numpy as np
 from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
+from tlz import unique
 
 from dask.dataframe import methods
 from dask.dataframe.core import split_evenly
+from dask.dataframe.utils import is_series_like
 
 from dask_match.expr import Expr
 
 
 class Repartition(Expr):
-    _parameters = ["frame", "n", "new_divisions"]
+    """Abstract repartitioning expression"""
+
+    _parameters = ["frame", "n", "new_divisions", "force"]
 
     @property
     def _meta(self):
@@ -19,7 +25,7 @@ class Repartition(Expr):
 
     def _divisions(self):
         if self.n is not None:
-            return (None,) * (self.n + 1)
+            return self.simplify()._divisions()
         return self.new_divisions
 
     def simplify(self):
@@ -27,18 +33,62 @@ class Repartition(Expr):
             if self.n < self.frame.npartitions:
                 return ReducePartitionCount(self.frame, self.n)
             else:
-                divisions = pd.Series(self.frame.divisions).drop_duplicates()
+                original_divisions = divisions = pd.Series(
+                    self.frame.divisions
+                ).drop_duplicates()
                 if self.frame.known_divisions and (
                     is_datetime64_any_dtype(divisions.dtype)
                     or is_numeric_dtype(divisions.dtype)
                 ):
-                    # Need to repartition by divisions
-                    raise NotImplementedError()  # TODO: repartition by divisions
-                return IncreasePartitionCount(self.frame, self.n)
-        raise NotImplementedError()  # TODO: repartition by divisions
+                    npartitions = self.n
+                    df = self.frame
+                    if is_datetime64_any_dtype(divisions.dtype):
+                        divisions = divisions.values.astype("float64")
+
+                    if is_series_like(divisions):
+                        divisions = divisions.values
+
+                    n = len(divisions)
+                    divisions = np.interp(
+                        x=np.linspace(0, n, npartitions + 1),
+                        xp=np.linspace(0, n, n),
+                        fp=divisions,
+                    )
+                    if is_datetime64_any_dtype(original_divisions.dtype):
+                        divisions = methods.tolist(
+                            pd.Series(divisions).astype(original_divisions.dtype)
+                        )
+                    elif np.issubdtype(original_divisions.dtype, np.integer):
+                        divisions = divisions.astype(original_divisions.dtype)
+
+                    if isinstance(divisions, np.ndarray):
+                        divisions = divisions.tolist()
+
+                    divisions = list(divisions)
+                    divisions[0] = df.divisions[0]
+                    divisions[-1] = df.divisions[-1]
+
+                    # Ensure the computed divisions are unique
+                    divisions = list(unique(divisions[:-1])) + [divisions[-1]]
+                    return RepartitionDivisions(df, divisions, self.force)
+                else:
+                    return IncreasePartitionCount(self.frame, self.n)
+        elif self.new_divisions:
+            return RepartitionDivisions(self.frame, self.new_divisions, self.force)
+        else:
+            raise NotImplementedError()
 
 
-class ReducePartitionCount(Repartition):
+class RepartitionImpl(Repartition):
+    """Rapartition-implementation base class"""
+
+    def simplify(self):
+        return None
+
+
+class ReducePartitionCount(RepartitionImpl):
+    """Reduce the partition count"""
+
     _parameters = ["frame", "n"]
 
     def _divisions(self):
@@ -77,7 +127,9 @@ class ReducePartitionCount(Repartition):
         }
 
 
-class IncreasePartitionCount(Repartition):
+class IncreasePartitionCount(RepartitionImpl):
+    """Increase the partition count"""
+
     _parameters = ["frame", "n"]
 
     def _divisions(self):
@@ -110,3 +162,151 @@ class IncreasePartitionCount(Repartition):
                     dsk[new_name, j] = (getitem, (split_name, i), jj)
                     j += 1
         return dsk
+
+
+class RepartitionDivisions(RepartitionImpl):
+    """Repartition to specific divisions"""
+
+    _parameters = ["frame", "new_divisions", "force"]
+    _defaults = {"force": False}
+
+    def _divisions(self):
+        return self.new_divisions
+
+    def _layer(self):
+        # Simplify copy from dask.dataframe
+        token = self._name.split("-")[-1]
+        a = self.frame.divisions
+        b = self.new_divisions
+        name = self.frame._name
+        out1 = "repartition-split-" + token
+        out2 = self._name
+        force = self.force
+
+        if len(b) < 2:
+            # minimum division is 2 elements, like [0, 0]
+            raise ValueError("New division must be longer than 2 elements")
+
+        if force:
+            if a[0] < b[0]:
+                msg = (
+                    "left side of the new division must be equal or smaller "
+                    "than old division"
+                )
+                raise ValueError(msg)
+            if a[-1] > b[-1]:
+                msg = (
+                    "right side of the new division must be equal or larger "
+                    "than old division"
+                )
+                raise ValueError(msg)
+        else:
+            if a[0] != b[0]:
+                msg = "left side of old and new divisions are different"
+                raise ValueError(msg)
+            if a[-1] != b[-1]:
+                msg = "right side of old and new divisions are different"
+                raise ValueError(msg)
+
+        def _is_single_last_div(x):
+            """Whether last division only contains single label"""
+            return len(x) >= 2 and x[-1] == x[-2]
+
+        c = [a[0]]
+        d = dict()
+        low = a[0]
+
+        i, j = 1, 1  # indices for old/new divisions
+        k = 0  # index for temp divisions
+
+        last_elem = _is_single_last_div(a)
+
+        # process through old division
+        # left part of new division can be processed in this loop
+        while i < len(a) and j < len(b):
+            if a[i] < b[j]:
+                # tuple is something like:
+                # (methods.boundary_slice, ('from_pandas-#', 0), 3, 4, False))
+                d[(out1, k)] = (methods.boundary_slice, (name, i - 1), low, a[i], False)
+                low = a[i]
+                i += 1
+            elif a[i] > b[j]:
+                d[(out1, k)] = (methods.boundary_slice, (name, i - 1), low, b[j], False)
+                low = b[j]
+                j += 1
+            else:
+                d[(out1, k)] = (methods.boundary_slice, (name, i - 1), low, b[j], False)
+                low = b[j]
+                if len(a) == i + 1 or a[i] < a[i + 1]:
+                    j += 1
+                i += 1
+            c.append(low)
+            k += 1
+
+        # right part of new division can remain
+        if a[-1] < b[-1] or b[-1] == b[-2]:
+            for _j in range(j, len(b)):
+                # always use right-most of old division
+                # because it may contain last element
+                m = len(a) - 2
+                d[(out1, k)] = (methods.boundary_slice, (name, m), low, b[_j], False)
+                low = b[_j]
+                c.append(low)
+                k += 1
+        else:
+            # even if new division is processed through,
+            # right-most element of old division can remain
+            if last_elem and i < len(a):
+                d[(out1, k)] = (
+                    methods.boundary_slice,
+                    (name, i - 1),
+                    a[i],
+                    a[i],
+                    False,
+                )
+                k += 1
+            c.append(a[-1])
+
+        # replace last element of tuple with True
+        d[(out1, k - 1)] = d[(out1, k - 1)][:-1] + (True,)
+
+        i, j = 0, 1
+
+        last_elem = _is_single_last_div(c)
+
+        while j < len(b):
+            tmp = []
+            while c[i] < b[j]:
+                tmp.append((out1, i))
+                i += 1
+            while (
+                last_elem
+                and c[i] == b[-1]
+                and (b[-1] != b[-2] or j == len(b) - 1)
+                and i < k
+            ):
+                # append if last split is not included
+                tmp.append((out1, i))
+                i += 1
+            if len(tmp) == 0:
+                # dummy slice to return empty DataFrame or Series,
+                # which retain original data attributes (columns / name)
+                d[(out2, j - 1)] = (
+                    methods.boundary_slice,
+                    (name, 0),
+                    a[0],
+                    a[0],
+                    False,
+                )
+            elif len(tmp) == 1:
+                d[(out2, j - 1)] = tmp[0]
+            else:
+                if not tmp:
+                    raise ValueError(
+                        "check for duplicate partitions\nold:\n%s\n\n"
+                        "new:\n%s\n\ncombined:\n%s"
+                        % (pformat(a), pformat(b), pformat(c))
+                    )
+                d[(out2, j - 1)] = (methods.concat, tmp)
+            j += 1
+        return d

--- a/dask_match/repartition.py
+++ b/dask_match/repartition.py
@@ -86,10 +86,6 @@ class Repartition(Expr):
         # Reorder with column projection
         if isinstance(parent, Projection):
             return type(self)(self.frame[parent.columns], *self.operands[1:])
-        # Reorder with filter
-        if isinstance(parent, Filter) and not isinstance(parent.predicate, Expr):
-            op = type(parent)(self.frame, parent.predicate)
-            return type(self)(op, *self.operands[1:])
 
 
 class RepartitionToFewer(Repartition):

--- a/dask_match/repartition.py
+++ b/dask_match/repartition.py
@@ -1,0 +1,112 @@
+import functools
+from operator import getitem
+
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
+
+from dask.dataframe import methods
+from dask.dataframe.core import split_evenly
+
+from dask_match.expr import Expr
+
+
+class Repartition(Expr):
+
+    _parameters = ["frame", "n", "new_divisions"]
+
+    @property
+    def _meta(self):
+        return self.frame._meta
+
+    def _divisions(self):
+        if self.n is not None:
+            return (None,) * (self.n + 1)
+        return self.new_divisions
+
+    def simplify(self):
+        if self.n is not None:
+            if self.n < self.frame.npartitions:
+                return ReducePartitionCount(self.frame, self.n)
+            else:
+                divisions = pd.Series(self.frame.divisions).drop_duplicates()
+                if self.frame.known_divisions and (
+                    is_datetime64_any_dtype(divisions.dtype)
+                    or is_numeric_dtype(divisions.dtype)
+                ):
+                    # Need to repartition by divisions
+                    raise NotImplementedError()  # TODO: repartition by divisions
+                return IncreasePartitionCount(self.frame, self.n)
+        raise NotImplementedError()  # TODO: repartition by divisions
+
+
+class ReducePartitionCount(Repartition):
+    _parameters = ["frame", "n"]
+
+    def _divisions(self):
+        return tuple(self.frame.divisions[i] for i in self._partitions_boundaries)
+
+    @functools.cached_property
+    def _partitions_boundaries(self):
+        npartitions = self.n
+        npartitions_input = self.frame.npartitions
+        assert npartitions_input > self.n
+
+        npartitions_ratio = npartitions_input / npartitions
+        new_partitions_boundaries = [
+            int(new_partition_index * npartitions_ratio)
+            for new_partition_index in range(npartitions + 1)
+        ]
+
+        if not isinstance(new_partitions_boundaries, list):
+            new_partitions_boundaries = list(new_partitions_boundaries)
+        if new_partitions_boundaries[0] > 0:
+            new_partitions_boundaries.insert(0, 0)
+        if new_partitions_boundaries[-1] < self.frame.npartitions:
+            new_partitions_boundaries.append(self.frame.npartitions)
+        return new_partitions_boundaries
+
+    def _layer(self):
+        new_partitions_boundaries = self._partitions_boundaries
+        return {
+            (self._name, i): (
+                methods.concat,
+                [(self.frame._name, j) for j in range(start, end)],
+            )
+            for i, (start, end) in enumerate(
+                zip(new_partitions_boundaries, new_partitions_boundaries[1:])
+            )
+        }
+    
+class IncreasePartitionCount(Repartition):
+    _parameters = ["frame", "n"]
+
+    def _divisions(self):
+        return (None,) * (1 + sum(self._nsplits))
+
+    @functools.cached_property
+    def _nsplits(self):
+        df = self.frame
+        div, mod = divmod(self.n, df.npartitions)
+        nsplits = [div] * df.npartitions
+        nsplits[-1] += mod
+        if len(nsplits) != df.npartitions:
+            raise ValueError(f"nsplits should have len={df.npartitions}")
+        return nsplits
+
+    def _layer(self):
+        dsk = {}
+        nsplits = self._nsplits
+        df = self.frame
+        new_name = self._name
+        split_name = f"split-{new_name}"
+        j = 0
+        for i, k in enumerate(nsplits):
+            if k == 1:
+                dsk[new_name, j] = (df._name, i)
+                j += 1
+            else:
+                dsk[split_name, i] = (split_evenly, (df._name, i), k)
+                for jj in range(k):
+                    dsk[new_name, j] = (getitem, (split_name, i), jj)
+                    j += 1
+        return dsk

--- a/dask_match/repartition.py
+++ b/dask_match/repartition.py
@@ -11,7 +11,6 @@ from dask_match.expr import Expr
 
 
 class Repartition(Expr):
-
     _parameters = ["frame", "n", "new_divisions"]
 
     @property
@@ -76,7 +75,8 @@ class ReducePartitionCount(Repartition):
                 zip(new_partitions_boundaries, new_partitions_boundaries[1:])
             )
         }
-    
+
+
 class IncreasePartitionCount(Repartition):
     _parameters = ["frame", "n"]
 

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -334,3 +334,10 @@ def test_map_partitions_broadcast(df):
 
     df2 = df.map_partitions(combine_x_y, df["x"].sum(), 123, foo="bar")
     assert_eq(df2, df + df["x"].sum() + 123)
+
+
+@pytest.mark.parametrize("npartitions", [7, 12])
+def test_repartition_npartitions(df, npartitions):
+    df2 = df.repartition(npartitions=npartitions)
+    assert df2.npartitions == npartitions
+    assert_eq(df, df2)

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -347,13 +347,15 @@ def test_repartition_npartitions(pdf, npartitions, sort):
     assert_eq(df, df2)
 
 
-def test_repartition_divisions(df):
+@pytest.mark.parametrize("opt", [True, False])
+def test_repartition_divisions(df, opt):
     end = df.divisions[-1] + 100
     stride = end // (df.npartitions + 2)
     divisions = tuple(range(0, end, stride))
-    df2 = (df + 1).repartition(divisions=divisions, force=True)
+    df2 = (df + 1).repartition(divisions=divisions, force=True)["x"]
+    df2 = optimize(df2) if opt else df2
     assert df2.divisions == divisions
-    assert_eq(df + 1, df2)
+    assert_eq((df + 1)["x"], df2)
 
     # Check partitions
     for p, part in enumerate(dask.compute(list(df2.index.partitions))[0]):


### PR DESCRIPTION
Adds an abstract `Repartition` expression, and subclasses for `npartitions` and `divisions`-based repartitioning.