### PR TITLE
Enhance simplify with simplify_up, remove replacement rules

### DIFF
--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -345,7 +345,7 @@ def read_csv(*args, **kwargs):
 def read_parquet(
     path=None,
     columns=None,
-    filters=None,
+    filters=(),
     categories=None,
     index=None,
     storage_options=None,

--- a/dask_match/collection.py
+++ b/dask_match/collection.py
@@ -79,13 +79,16 @@ class FrameBase(DaskMethodsMixin):
 
     def __dask_graph__(self):
         out = self.expr
-        out, _ = expr.simplify(out)
+        out = out.simplify()
         return out.__dask_graph__()
 
     def __dask_keys__(self):
         out = self.expr
-        out, _ = expr.simplify(out)
+        out = out.simplify()
         return out.__dask_keys__()
+
+    def simplify(self):
+        return new_collection(self.expr.simplify())
 
     @property
     def dask(self):

--- a/dask_match/io/parquet.py
+++ b/dask_match/io/parquet.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from functools import cached_property, partial
+from functools import cached_property
 
 from dask.dataframe.io.parquet.core import (
     ParquetFunctionWrapper,
@@ -10,7 +10,6 @@ from dask.dataframe.io.parquet.core import (
 )
 from dask.dataframe.io.parquet.utils import _split_user_options
 from dask.utils import natural_sort_key
-from matchpy import CustomConstraint, Pattern, ReplacementRule, Wildcard
 
 from dask_match.expr import EQ, GE, GT, LE, LT, NE, Filter, Projection
 from dask_match.io import BlockwiseIO
@@ -81,71 +80,36 @@ class ReadParquet(BlockwiseIO):
     def _simplify_up(self, parent):
         if isinstance(parent, Projection):
             operands = list(self.operands)
-            operands[self._parameters.index("columns")] = parent.operand("columns")
+            operands[self._parameters.index("columns")] = _list_columns(
+                parent.operand("columns")
+            )
             return ReadParquet(*operands)
 
-    @classmethod
-    def _replacement_rules(cls):
-        # All wildcards defined here.
-        # Note that "x" corresponds to a column selection, and
-        # "y" corresponds to a literal filter-comparison value
-        _ = Wildcard.dot()
-        path, columns, filters, x, y = map(
-            Wildcard.dot, ["path", "columns", "filters", "x", "y"]
-        )
-        other = {w.variable_name: w for w in map(Wildcard.dot, cls._parameters[3:])}
-
-        # Simple dict to make sure field comes first in filter
-        flip_op = {LE: GE, LT: GT, GE: LE, GT: LT}
-
-        # Predicate pushdown to parquet
-        for op in [LE, LT, GE, GT, EQ, NE]:
-
-            def predicate_pushdown(path, columns, filters, x, y, op=None, **kwargs):
-                return ReadParquet(
-                    path,
-                    columns=_list_columns(columns),
-                    filters=(filters or []) + [(x, op._operator_repr, y)],
-                    **kwargs,
-                )
-
-            pattern = Pattern(
-                Filter(
-                    ReadParquet(path, columns=columns, filters=filters, **other),
-                    op(ReadParquet(path, columns=_, filters=_, **other)[x], y),
-                )
-            )
-            replace = partial(predicate_pushdown, op=op)
-            yield ReplacementRule(pattern, replace)
-
-            pattern = Pattern(
-                Filter(
-                    ReadParquet(path, columns=columns, filters=filters, **other),
-                    op(y, ReadParquet(path, columns=_, filters=_, **other)[x]),
-                )
-            )
-            replace = partial(predicate_pushdown, op=flip_op.get(op, op))
-            yield ReplacementRule(pattern, replace)
-
-            pattern = Pattern(
-                Filter(
-                    ReadParquet(path, columns=columns, filters=filters, **other),
-                    op(ReadParquet(path, columns=x, filters=_, **other), y),
-                ),
-                CustomConstraint(lambda x: isinstance(x, str)),
-            )
-            replace = partial(predicate_pushdown, op=op)
-            yield ReplacementRule(pattern, replace)
-
-            pattern = Pattern(
-                Filter(
-                    ReadParquet(path, columns=columns, filters=filters, **other),
-                    op(y, ReadParquet(path, columns=x, filters=_, **other)),
-                ),
-                CustomConstraint(lambda x: isinstance(x, str)),
-            )
-            replace = partial(predicate_pushdown, op=flip_op.get(op, op))
-            yield ReplacementRule(pattern, replace)
+        if isinstance(parent, Filter) and isinstance(
+            parent.predicate, (LE, GE, LT, GT, EQ, NE)
+        ):
+            kwargs = dict(zip(self._parameters, self.operands))
+            if (
+                isinstance(parent.predicate.left, ReadParquet)
+                and parent.predicate.left.path == self.path
+            ):
+                op = parent.predicate._operator_repr
+                column = parent.predicate.left.columns[0]
+                value = parent.predicate.right
+                kwargs["filters"] = kwargs["filters"] + ((column, op, value),)
+                return ReadParquet(**kwargs)
+            if (
+                isinstance(parent.predicate.right, ReadParquet)
+                and parent.predicate.right.path == self.path
+            ):
+                # Simple dict to make sure field comes first in filter
+                flip = {LE: GE, LT: GT, GE: LE, GT: LT}
+                op = parent.predicate
+                op = flip.get(op, op)._operator_repr
+                column = parent.predicate.right.columns[0]
+                value = parent.predicate.left
+                kwargs["filters"] = kwargs["filters"] + ((column, op, value),)
+                return ReadParquet(**kwargs)
 
     @cached_property
     def _dataset_info(self):

--- a/dask_match/io/tests/test_io.py
+++ b/dask_match/io/tests/test_io.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from dask.dataframe.utils import assert_eq
 
-from dask_match import from_pandas, optimize, read_parquet, read_csv
+from dask_match import from_pandas, optimize, read_csv, read_parquet
 
 
 def _make_file(dir, format="parquet", df=None):
@@ -94,7 +94,7 @@ def test_predicate_pushdown(tmpdir):
     df = read_parquet(fn)
     assert_eq(df, original)
     x = df[df.a == 5][df.c > 20]["b"]
-    y = optimize(x)
+    y = optimize(x, fuse=False)
     assert isinstance(y.expr, ReadParquet)
     assert ("a", "==", 5) in y.expr.operand("filters") or (
         "a",

--- a/dask_match/reductions.py
+++ b/dask_match/reductions.py
@@ -220,7 +220,7 @@ class Len(Reduction):
     reduction_chunk = staticmethod(len)
     reduction_aggregate = sum
 
-    def simplify(self):
+    def _simplify_down(self):
         if isinstance(self.frame, Elemwise):
             child = max(self.frame.dependencies(), key=lambda expr: expr.npartitions)
             return Len(child)
@@ -230,7 +230,7 @@ class Size(Reduction):
     reduction_chunk = staticmethod(lambda df: df.size)
     reduction_aggregate = sum
 
-    def simplify(self):
+    def _simplify_down(self):
         if is_dataframe_like(self.frame) and len(self.frame.columns) > 1:
             return len(self.frame.columns) * Len(self.frame)
         else:
@@ -247,7 +247,7 @@ class Mean(Reduction):
             self.frame._meta.sum(skipna=self.skipna, numeric_only=self.numeric_only) / 2
         )
 
-    def simplify(self):
+    def _simplify_down(self):
         return (
             self.frame.sum(skipna=self.skipna, numeric_only=self.numeric_only)
             / self.frame.count()

--- a/dask_match/tests/test_collection.py
+++ b/dask_match/tests/test_collection.py
@@ -251,7 +251,7 @@ def test_partitions(pdf, df):
     assert_eq(df.partitions[[3, 4]], pdf.iloc[30:50])
     assert_eq(df.partitions[-1], pdf.iloc[90:])
 
-    out = (df + 1).partitions[0].simplify()
+    out = (df + 1).partitions[0].optimize(fuse=False)
     assert isinstance(out.expr, expr.Add)
     assert isinstance(out.expr.left, expr.Partitions)
 


### PR DESCRIPTION
Simplify is, I think, simpler and faster, but has the challenge that it only allows classes to optimize their subtree.  We use replacement rules today to optimize patterns that have to look above the term in the expression tree.

This PR renames simplify to `_simplify_down` and adds a new `_simplify_up` method that gets the parent term.  It then moves most of the replacement rules over to simplify.  I haven't yet moved over the parquet predicate pushdown rules, mosty because they're really complicated.  In general everything so far has felt simpler in this new method.

Additionally, I have a local commit which I'll push up separately which removes matchpy entirely.