### PR TITLE
Add `pre-commit` CI job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,18 @@
+name: Linting
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+jobs:
+  checks:
+    name: pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,7 @@ name: Linting
 
 on:
   push:
-    branches: "*"
+    branches: main
   pull_request:
     branches: main
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,7 @@ name: Linting
 
 on:
   push:
-    branches: main
+    branches: "*"
   pull_request:
     branches: main
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
       - id: debug-statements
@@ -10,18 +10,18 @@ repos:
       - id: absolufy-imports
         name: absolufy-imports
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         language_version: python3
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
+    rev: v3.3.2
     hooks:
       - id: pyupgrade
         args:
           - --py38-plus
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
       - id: black
         language_version: python3
@@ -29,7 +29,7 @@ repos:
         args:
           - --target-version=py38
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         language_version: python3
@@ -38,7 +38,7 @@ repos:
           #  dependency. Make sure to update flake8-bugbear manually on a regular basis.
           - flake8-bugbear==22.8.23
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.4
     hooks:
       -   id: codespell
           types_or: [rst, markdown]


### PR DESCRIPTION
This gets `pre-commit` running in CI -- though there are some linting failures. @rjzamora @mrocklin feel free to push directly to this branch if you want to 

Supersedes https://github.com/mrocklin/dask-match/pull/54